### PR TITLE
Remove build warnings (all) - fix spelling errors

### DIFF
--- a/Firmware/ConfigurationStore.h
+++ b/Firmware/ConfigurationStore.h
@@ -21,7 +21,7 @@ FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_Prin
 #endif
 
 inline uint8_t calibration_status() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS); }
-inline uint8_t calibration_status_store(uint8_t status) { eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS, status); }
+inline void calibration_status_store(uint8_t status) { eeprom_update_byte((uint8_t*)EEPROM_CALIBRATION_STATUS, status); }
 inline bool calibration_status_pinda() { return eeprom_read_byte((uint8_t*)EEPROM_CALIBRATION_STATUS_PINDA); }
 
 #endif//CONFIG_STORE_H

--- a/Firmware/MarlinSerial.cpp
+++ b/Firmware/MarlinSerial.cpp
@@ -56,8 +56,8 @@ FORCE_INLINE void store_char(unsigned char c)
       // Test for a framing error.
       if (M_UCSRxA & (1<<M_FEx)) {
           // Characters received with the framing errors will be ignored.
-          // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-          volatile unsigned char c = M_UDRx;
+          // Dummy register read (discard)
+          (void)(*(char *)M_UDRx);
       } else {
           // Read the input register.
           unsigned char c = M_UDRx;
@@ -71,8 +71,8 @@ FORCE_INLINE void store_char(unsigned char c)
         // Test for a framing error.
         if (UCSR2A & (1<<FE2)) {
             // Characters received with the framing errors will be ignored.
-            // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-            volatile unsigned char c = UDR2;
+            // Dummy register read (discard)
+            (void)(*(char *)UDR2);
         } else {
             // Read the input register.
             unsigned char c = UDR2;

--- a/Firmware/MarlinSerial.h
+++ b/Firmware/MarlinSerial.h
@@ -134,8 +134,7 @@ class MarlinSerial //: public Stream
                 // Test for a framing error.
                 if (M_UCSRxA & (1<<M_FEx)) {
                     // Characters received with the framing errors will be ignored.
-                    // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-                    volatile unsigned char c = M_UDRx;
+                    (void)(*(char *)M_UDRx);
                 } else {
                     unsigned char c  =  M_UDRx;
                     int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;
@@ -156,8 +155,7 @@ class MarlinSerial //: public Stream
                 // Test for a framing error.
                 if (M_UCSRxA & (1<<M_FEx)) {
                     // Characters received with the framing errors will be ignored.
-                    // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-                    volatile unsigned char c = M_UDRx;
+                    (void)(*(char *)M_UDRx);
                 } else {
                     unsigned char c  =  M_UDRx;
                     int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;
@@ -177,8 +175,7 @@ class MarlinSerial //: public Stream
                 // Test for a framing error.
                 if (UCSR2A & (1<<FE2)) {
                     // Characters received with the framing errors will be ignored.
-                    // The temporary variable "c" was made volatile, so the compiler does not optimize this out.
-                    volatile unsigned char c = UDR2;
+                    (void)(*(char *)UDR2);
                 } else {
                     unsigned char c  =  UDR2;
                     int i = (unsigned int)(rx_buffer.head + 1) % RX_BUFFER_SIZE;

--- a/Firmware/SdFatUtil.cpp
+++ b/Firmware/SdFatUtil.cpp
@@ -46,7 +46,7 @@ int SdFatUtil::FreeRam() {
 
 void SdFatUtil::set_stack_guard()
 {	
-	char i = 0;
+	//char i = 0;
 	uint32_t *stack_guard;
 
 	stack_guard = (uint32_t*)&__bss_end;

--- a/Firmware/cardreader.cpp
+++ b/Firmware/cardreader.cpp
@@ -61,7 +61,6 @@ char *createFilename(char *buffer,const dir_t &p) //buffer>12characters
 
 void CardReader::lsDive_pointer(const char *prepend, SdFile parent, const char * const match) {
 	dir_t p;
-	uint8_t cnt = 0;
 
 	//parent.seekSet = 
 	// Read the next entry from a directory
@@ -73,17 +72,11 @@ void CardReader::lsDive_pointer(const char *prepend, SdFile parent, const char *
 	//pom = parent.curPosition();
 	//MYSERIAL.println(pom, 10);
 
-			uint8_t pn0 = p.name[0];
+	filenameIsDir = DIR_IS_SUBDIR(&p);
 
-			filenameIsDir = DIR_IS_SUBDIR(&p);
-
-
-
-			
-			createFilename(filename, p);
-			creationDate = p.creationDate;
-			creationTime = p.creationTime;
-		
+	createFilename(filename, p);
+	creationDate = p.creationDate;
+	creationTime = p.creationTime;
 }
 
 /**
@@ -363,12 +356,12 @@ void CardReader::openFile(char* name,bool read, bool replace_current/*=true*/)
   if(name[0]=='/')
   {
     dirname_start=strchr(name,'/')+1;
-    while(dirname_start>0)
+    while(dirname_start)
     {
       dirname_end=strchr(dirname_start,'/');
       //SERIAL_ECHO("start:");SERIAL_ECHOLN((int)(dirname_start-name));
       //SERIAL_ECHO("end  :");SERIAL_ECHOLN((int)(dirname_end-name));
-      if(dirname_end>0 && dirname_end>dirname_start)
+      if(dirname_end && dirname_end>dirname_start)
       {
         char subdirname[13];
         strncpy(subdirname, dirname_start, dirname_end-dirname_start);
@@ -461,12 +454,12 @@ void CardReader::removeFile(char* name)
   if(name[0]=='/')
   {
     dirname_start=strchr(name,'/')+1;
-    while(dirname_start>0)
+    while(dirname_start)
     {
       dirname_end=strchr(dirname_start,'/');
       //SERIAL_ECHO("start:");SERIAL_ECHOLN((int)(dirname_start-name));
       //SERIAL_ECHO("end  :");SERIAL_ECHOLN((int)(dirname_end-name));
-      if(dirname_end>0 && dirname_end>dirname_start)
+      if(dirname_end && dirname_end>dirname_start)
       {
         char subdirname[13];
         strncpy(subdirname, dirname_start, dirname_end-dirname_start);
@@ -710,8 +703,7 @@ void CardReader::updir()
   {
     --workDirDepth;
     workDir = workDirParents[0];
-    int d;
-    for (int d = 0; d < workDirDepth; d++)
+    for (uint8_t d = 0; d < workDirDepth; d++)
       workDirParents[d] = workDirParents[d+1];
   }
 }

--- a/Firmware/language_all.cpp
+++ b/Firmware/language_all.cpp
@@ -2528,7 +2528,7 @@ const char MSG_SELFTEST_CHECK_BED_CZ[] PROGMEM = "Kontrola bed     ";
 const char MSG_SELFTEST_CHECK_BED_IT[] PROGMEM = "Verifica letto";
 const char MSG_SELFTEST_CHECK_BED_ES[] PROGMEM = "Control de cama";
 const char MSG_SELFTEST_CHECK_BED_PL[] PROGMEM = "Kontrola bed     ";
-const char MSG_SELFTEST_CHECK_BED_DE[] PROGMEM = "Pr\x81fe Bed        ";
+const char MSG_SELFTEST_CHECK_BED_DE[] PROGMEM = "Pr\x81""fe Bed        ";
 const char * const MSG_SELFTEST_CHECK_BED_LANG_TABLE[LANG_NUM] PROGMEM = {
 	MSG_SELFTEST_CHECK_BED_EN,
 	MSG_SELFTEST_CHECK_BED_CZ,

--- a/Firmware/language_de.h
+++ b/Firmware/language_de.h
@@ -181,7 +181,7 @@
 + #define(length = 20) MSG_SELFTEST_CHECK_X				"Pruefe X Achse    "
 + #define(length = 20) MSG_SELFTEST_CHECK_Y				"Pruefe Y Achse    "
 + #define(length = 20) MSG_SELFTEST_CHECK_Z				"Pruefe Z Achse    "
-+ #define(length = 20) MSG_SELFTEST_CHECK_BED			"Pr\x81fe Bed        "
++ #define(length = 20) MSG_SELFTEST_CHECK_BED			"Pr\x81""fe Bed        "
 + #define(length = 20) MSG_SELFTEST_CHECK_ALLCORRECT	"Alles richtig    "
 + #define MSG_SELFTEST						"Selbsttest       "
 + #define(length = 20) MSG_SELFTEST_FAILED		"Selbsttest misslung."
@@ -324,3 +324,4 @@
 #define MSG_MEASURED_SKEW					"Schraeglauf:"
 #define MSG_SLIGHT_SKEW						"Leichter Schr.:"
 #define MSG_SEVERE_SKEW						"Schwerer Schr.:"
+

--- a/Firmware/mesh_bed_calibration.cpp
+++ b/Firmware/mesh_bed_calibration.cpp
@@ -1599,7 +1599,6 @@ inline void scan_bed_induction_sensor_point()
     float x1 = center_old_x + IMPROVE_BED_INDUCTION_SENSOR_POINT3_SEARCH_RADIUS;
     float y0 = center_old_y - IMPROVE_BED_INDUCTION_SENSOR_POINT3_SEARCH_RADIUS;
     float y1 = center_old_y + IMPROVE_BED_INDUCTION_SENSOR_POINT3_SEARCH_RADIUS;
-    float y = y0;
 
     if (x0 < X_MIN_POS)
         x0 = X_MIN_POS;
@@ -2271,11 +2270,11 @@ bool sample_mesh_and_store_reference()
     {
         // Verify the span of the Z values.
         float zmin = mbl.z_values[0][0];
-        float zmax = zmax;
+        float zmax = zmin;
         for (int8_t j = 0; j < 3; ++ j)
            for (int8_t i = 0; i < 3; ++ i) {
                 zmin = min(zmin, mbl.z_values[j][i]);
-                zmax = min(zmax, mbl.z_values[j][i]);
+                zmax = max(zmax, mbl.z_values[j][i]);
            }
         if (zmax - zmin > 3.f) {
             // The span of the Z offsets is extreme. Give up.
@@ -2446,7 +2445,7 @@ void babystep_reset()
 }
 
 void count_xyz_details() {
-	float a1, a2;
+	//float a1, a2;
 	float cntr[2] = {
 		eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER + 0)),
 		eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER + 4))
@@ -2474,14 +2473,15 @@ void count_xyz_details() {
 	SERIAL_ECHOPGM("Calibration status:");
 	MYSERIAL.println(int(calibration_status()));
 
-	a2 = -1 * asin(vec_y[0] / MACHINE_AXIS_SCALE_Y);
-/*	SERIAL_ECHOLNPGM("par:");
+/*	a2 = -1 * asin(vec_y[0] / MACHINE_AXIS_SCALE_Y);
+	SERIAL_ECHOLNPGM("par:");
 	MYSERIAL.println(vec_y[0]);
-	MYSERIAL.println(a2);*/
+	MYSERIAL.println(a2);
 	a1 = asin(vec_x[1] / MACHINE_AXIS_SCALE_X);
-/*	MYSERIAL.println(vec_x[1]);
-	MYSERIAL.println(a1);*/
-	//angleDiff = fabs(a2 - a1);
+	MYSERIAL.println(vec_x[1]);
+	MYSERIAL.println(a1);
+	angleDiff = fabs(a2 - a1);
+*/
 	for (uint8_t mesh_point = 0; mesh_point < 3; ++mesh_point) {
 		float y = vec_x[1] * pgm_read_float(bed_ref_points + mesh_point * 2) + vec_y[1] * pgm_read_float(bed_ref_points + mesh_point * 2 + 1) + cntr[1];
 		distance_from_min[mesh_point] = (y - Y_MIN_POS_CALIBRATION_POINT_OUT_OF_REACH);

--- a/Firmware/pins.h
+++ b/Firmware/pins.h
@@ -3,20 +3,6 @@
 
 #include "boards.h"
 
-#if !MB(5DPRINT)
-#define X_MS1_PIN -1
-#define X_MS2_PIN -1
-#define Y_MS1_PIN -1
-#define Y_MS2_PIN -1
-#define Z_MS1_PIN -1
-#define Z_MS2_PIN -1
-#define E0_MS1_PIN -1
-#define E0_MS2_PIN -1
-#define E1_MS1_PIN -1
-#define E1_MS2_PIN -1
-#define DIGIPOTSS_PIN -1
-#endif
-
 #define LARGE_FLASH true
 
 /*****************************************************************
@@ -38,22 +24,16 @@
 
   #define X_STEP_PIN 37
   #define X_DIR_PIN 48
-  #define X_MIN_PIN 12
-  #define X_MAX_PIN 30
   #define X_ENABLE_PIN 29
   #define X_MS1_PIN 40
   #define X_MS2_PIN 41
   #define Y_STEP_PIN 36
   #define Y_DIR_PIN 49
-  #define Y_MIN_PIN 11
-  #define Y_MAX_PIN 24
   #define Y_ENABLE_PIN 28
   #define Y_MS1_PIN 69
   #define Y_MS2_PIN 39
   #define Z_STEP_PIN 35
   #define Z_DIR_PIN 47
-  #define Z_MIN_PIN 10
-  #define Z_MAX_PIN 23
   #define Z_ENABLE_PIN 27
   #define Z_MS1_PIN 68
   #define Z_MS2_PIN 67
@@ -63,6 +43,27 @@
   #define TEMP_1_PIN 1
   #define TEMP_2_PIN -1
   
+#ifndef DISABLE_MAX_ENDSTOPS
+  #define X_MAX_PIN 30
+  #define Z_MAX_PIN 23
+  #define Y_MAX_PIN 24
+#else
+  #define X_MAX_PIN -1
+  #define Y_MAX_PIN -1
+  #define Z_MAX_PIN -1
+#endif
+
+#ifndef DISABLE_MIN_ENDSTOPS
+  #define X_MIN_PIN 12
+  #define Y_MIN_PIN 11
+  #define Z_MIN_PIN 10
+#else
+  #define X_MIN_PIN -1
+  #define Y_MIN_PIN -1
+  #define Z_MIN_PIN -1
+#endif
+
+
 #ifdef SNMM 
 
 #define E_MUX0_PIN 17
@@ -234,22 +235,16 @@
   #define LARGE_FLASH true
   #define X_STEP_PIN 37
   #define X_DIR_PIN 48
-  #define X_MIN_PIN 12
-  #define X_MAX_PIN 30
   #define X_ENABLE_PIN 29
   #define X_MS1_PIN 40
   #define X_MS2_PIN 41
   #define Y_STEP_PIN 36
   #define Y_DIR_PIN 49
-  #define Y_MIN_PIN 11
-  #define Y_MAX_PIN 24
   #define Y_ENABLE_PIN 28
   #define Y_MS1_PIN 69
   #define Y_MS2_PIN 39
   #define Z_STEP_PIN 35
   #define Z_DIR_PIN 47
-  #define Z_MIN_PIN 10
-  #define Z_MAX_PIN 23
   #define Z_ENABLE_PIN 27
   #define Z_MS1_PIN 68
   #define Z_MS2_PIN 67
@@ -259,6 +254,26 @@
   #define TEMP_1_PIN 1
   #define TEMP_2_PIN -1
   
+#ifndef DISABLE_MAX_ENDSTOPS
+  #define X_MAX_PIN 30
+  #define Z_MAX_PIN 23
+  #define Y_MAX_PIN 24
+#else
+  #define X_MAX_PIN -1
+  #define Y_MAX_PIN -1
+  #define Z_MAX_PIN -1
+#endif
+
+#ifndef DISABLE_MIN_ENDSTOPS
+  #define X_MIN_PIN 12
+  #define Y_MIN_PIN 11
+  #define Z_MIN_PIN 10
+#else
+  #define X_MIN_PIN -1
+  #define Y_MIN_PIN -1
+  #define Z_MIN_PIN -1
+#endif
+
   // The SDSS pin uses a different pin mapping from file Sd2PinMap.h
 #define SDSS               53
 
@@ -364,17 +379,6 @@
   #endif
 #endif
 
-#ifdef DISABLE_MAX_ENDSTOPS
-#define X_MAX_PIN          -1
-#define Y_MAX_PIN          -1
-#define Z_MAX_PIN          -1
-#endif
-
-#ifdef DISABLE_MIN_ENDSTOPS
-#define X_MIN_PIN          -1
-#define Y_MIN_PIN          -1
-#define Z_MIN_PIN          -1
-#endif
 
 #define SENSITIVE_PINS {0, 1, X_STEP_PIN, X_DIR_PIN, X_ENABLE_PIN, X_MIN_PIN, X_MAX_PIN, Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, Y_MIN_PIN, Y_MAX_PIN, Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, Z_MIN_PIN, Z_MAX_PIN, PS_ON_PIN, \
                         HEATER_BED_PIN, FAN_PIN,                  \

--- a/Firmware/planner.cpp
+++ b/Firmware/planner.cpp
@@ -1029,16 +1029,20 @@ Having the real displacement of the head, we can calculate the total movement le
   // Acceleration of the segment, in mm/sec^2
   block->acceleration = block->acceleration_st / steps_per_mm;
 
-#if 1
+#if 0
   // Oversample diagonal movements by a power of 2 up to 8x
   // to achieve more accurate diagonal movements.
   uint8_t bresenham_oversample = 1;
   for (uint8_t i = 0; i < 3; ++ i) {
     if (block->nominal_rate >= 5000) // 5kHz
       break;
-    block->nominal_rate << 1;
-    bresenham_oversample << 1;
-    block->step_event_count << 1;
+    // The following statements in their original form did nothing (missing =).
+    // In effect, this entire block under the conditional was doing nothing.
+    // Adding the syntax correction did not produce good movement results therefore
+    // it has been disabled (above)
+    block->nominal_rate <<= 1;
+    bresenham_oversample <<= 1;
+    block->step_event_count <<= 1;
   }
   if (bresenham_oversample > 1)
     // Lower the acceleration steps/sec^2 to account for the oversampling.

--- a/Firmware/stepper.cpp
+++ b/Firmware/stepper.cpp
@@ -74,11 +74,18 @@ bool abort_on_endstop_hit = false;
 #endif
 
 static bool old_x_min_endstop=false;
-static bool old_x_max_endstop=false;
 static bool old_y_min_endstop=false;
-static bool old_y_max_endstop=false;
 static bool old_z_min_endstop=false;
+
+#if defined(X_MAX_PIN) && (X_MAX_PIN > -1)
+static bool old_x_max_endstop=false;
+#endif
+#if defined(Y_MAX_PIN) && (Y_MAX_PIN > -1)
+static bool old_y_max_endstop=false;
+#endif
+#if defined(Z_MAX_PIN) && (Z_MAX_PIN > -1)
 static bool old_z_max_endstop=false;
+#endif
 
 static bool check_endstops = true;
 static bool check_z_endstop = false;
@@ -1066,9 +1073,7 @@ void babystep(const uint8_t axis,const bool direction)
     
     //perform step 
     WRITE(X_STEP_PIN, !INVERT_X_STEP_PIN); 
-    {
-    volatile float x=1./float(axis+1)/float(axis+2); //wait a tiny bit
-    }
+    delayMicroseconds(3);
     WRITE(X_STEP_PIN, INVERT_X_STEP_PIN);
 
     //get old pin state back.
@@ -1085,9 +1090,7 @@ void babystep(const uint8_t axis,const bool direction)
     
     //perform step 
     WRITE(Y_STEP_PIN, !INVERT_Y_STEP_PIN); 
-    {
-    volatile float x=1./float(axis+1)/float(axis+2); //wait a tiny bit
-    }
+    delayMicroseconds(3);
     WRITE(Y_STEP_PIN, INVERT_Y_STEP_PIN);
 
     //get old pin state back.
@@ -1109,11 +1112,11 @@ void babystep(const uint8_t axis,const bool direction)
     WRITE(Z_STEP_PIN, !INVERT_Z_STEP_PIN); 
     #ifdef Z_DUAL_STEPPER_DRIVERS
       WRITE(Z2_STEP_PIN, !INVERT_Z_STEP_PIN);
+      delayMicroseconds(2);
+    #else
+      delayMicroseconds(3);
     #endif
-    //wait a tiny bit
-    {
-    volatile float x=1./float(axis+1); //absolutely useless
-    }
+
     WRITE(Z_STEP_PIN, INVERT_Z_STEP_PIN);
     #ifdef Z_DUAL_STEPPER_DRIVERS
       WRITE(Z2_STEP_PIN, INVERT_Z_STEP_PIN);

--- a/Firmware/temperature.cpp
+++ b/Firmware/temperature.cpp
@@ -182,6 +182,14 @@ unsigned long watchmillis[EXTRUDERS] = ARRAY_BY_EXTRUDERS(0,0,0);
 #ifdef FILAMENT_SENSOR
   static int meas_shift_index;  //used to point to a delayed sample in buffer for filament width sensor
 #endif
+
+#if (defined (TEMP_RUNAWAY_BED_HYSTERESIS) && TEMP_RUNAWAY_BED_TIMEOUT > 0) || (defined (TEMP_RUNAWAY_EXTRUDER_HYSTERESIS) && TEMP_RUNAWAY_EXTRUDER_TIMEOUT > 0)
+static float temp_runaway_status[4];
+static float temp_runaway_target[4];
+static float temp_runaway_timer[4];
+static int temp_runaway_error_counter[4];
+#endif
+
 //===========================================================================
 //=============================   functions      ============================
 //===========================================================================
@@ -1417,7 +1425,9 @@ ISR(TIMER0_COMPB_vect)
   static unsigned char temp_count = 0;
   static unsigned long raw_temp_0_value = 0;
   static unsigned long raw_temp_1_value = 0;
+#if defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
   static unsigned long raw_temp_2_value = 0;
+#endif
   static unsigned long raw_temp_bed_value = 0;
   static unsigned char temp_state = 10;
   static unsigned char pwm_count = (1 << SOFT_PWM_SCALE);
@@ -1857,7 +1867,7 @@ ISR(TIMER0_COMPB_vect)
 #ifdef TEMP_SENSOR_1_AS_REDUNDANT
       redundant_temperature_raw = raw_temp_1_value;
 #endif
-#if EXTRUDERS > 2
+#if (EXTRUDERS > 2) && defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
       current_temperature_raw[2] = raw_temp_2_value;
 #endif
       current_temperature_bed_raw = raw_temp_bed_value;
@@ -1873,7 +1883,9 @@ ISR(TIMER0_COMPB_vect)
     temp_count = 0;
     raw_temp_0_value = 0;
     raw_temp_1_value = 0;
+#if defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
     raw_temp_2_value = 0;
+#endif
     raw_temp_bed_value = 0;
 
 #if HEATER_0_RAW_LO_TEMP > HEATER_0_RAW_HI_TEMP

--- a/Firmware/temperature.h
+++ b/Firmware/temperature.h
@@ -176,11 +176,6 @@ FORCE_INLINE bool isCoolingBed() {
 #endif
 
 #if (defined (TEMP_RUNAWAY_BED_HYSTERESIS) && TEMP_RUNAWAY_BED_TIMEOUT > 0) || (defined (TEMP_RUNAWAY_EXTRUDER_HYSTERESIS) && TEMP_RUNAWAY_EXTRUDER_TIMEOUT > 0)
-static float temp_runaway_status[4];
-static float temp_runaway_target[4];
-static float temp_runaway_timer[4];
-static int temp_runaway_error_counter[4];
-
 void temp_runaway_check(int _heater_id, float _target_temperature, float _current_temperature, float _output, bool _isbed);
 void temp_runaway_stop(bool isPreheat, bool isBed);
 #endif

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -29,20 +29,11 @@
   void prusa_statistics(int _message, uint8_t _col_nr = 0);
   void lcd_confirm_print();
   unsigned char lcd_choose_color();
-void lcd_mylang();
+  void lcd_mylang();
   bool lcd_detected(void);
 
   
-  static bool lcd_selftest();
-  static bool lcd_selfcheck_endstops();
-  static bool lcd_selfcheck_axis(int _axis, int _travel);
-  static bool lcd_selfcheck_check_heater(bool _isbed);
-  static int  lcd_selftest_screen(int _step, int _progress, int _progress_scale, bool _clear, int _delay);
-  static void lcd_selftest_screen_step(int _row, int _col, int _state, const char *_name, const char *_indicator);
-  static bool lcd_selftest_fan_dialog(int _fan);
-  static void lcd_selftest_error(int _error_no, const char *_error_1, const char *_error_2);
   void lcd_menu_statistics();
-  static bool lcd_selfcheck_pulleys(int axis);
 
   
   extern const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines);
@@ -66,8 +57,6 @@ void lcd_mylang();
   extern int lcd_contrast;
   void lcd_setcontrast(uint8_t value);
 #endif
-
-  static unsigned char blink = 0;	// Variable for visualization of fan rotation in GLCD
 
   #define LCD_MESSAGEPGM(x) lcd_setstatuspgm(PSTR(x))
   #define LCD_ALERTMESSAGEPGM(x) lcd_setalertstatuspgm(PSTR(x))
@@ -212,31 +201,12 @@ extern void lcd_implementation_print_at(uint8_t x, uint8_t y, const char *str);
 
 
 void change_extr(int extr);
-static void lcd_colorprint_change();
-static int get_ext_nr();
+int get_ext_nr();
 void extr_adj(int extruder);
-static void extr_adj_0();
-static void extr_adj_1();
-static void extr_adj_2();
-static void extr_adj_3();
-static void fil_load_menu();
-static void fil_unload_menu();
-static void extr_unload_0();
-static void extr_unload_1();
-static void extr_unload_2();
-static void extr_unload_3();
-static void lcd_disable_farm_mode();
 void extr_unload_all(); 
 void extr_unload_used();
 void extr_unload();
-static char snmm_stop_print_menu();
-static void lcd_babystep_z();
-#ifdef SDCARD_SORT_ALPHA
-static void lcd_sort_type_set();
-#endif
-static float count_e(float layer_heigth, float extrusion_width, float extrusion_length);
 void stack_error();
-static void lcd_ping_allert();
 void lcd_printer_connected();
 void lcd_ping();
 
@@ -270,9 +240,6 @@ void lcd_service_mode_show_result();
 void lcd_set_degree();
 void lcd_set_progress();
 #endif
-
-static void lcd_send_status();
-static void lcd_connect_printer();
 
 void lcd_wizard();
 void lcd_wizard(int state);

--- a/Firmware/ultralcd_implementation_hitachi_HD44780.h
+++ b/Firmware/ultralcd_implementation_hitachi_HD44780.h
@@ -360,6 +360,7 @@ static void lcd_set_custom_characters(
     B00000
   }; //thanks Sonny Mounicou
 
+#if 0	// Unused
   byte arrup[8] = {
     B00100,
     B01110,
@@ -381,7 +382,7 @@ static void lcd_set_custom_characters(
     B01010,
     B00100
   }; 
-
+#endif
 
   #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
     static bool char_mode = false;
@@ -603,16 +604,15 @@ static void lcd_implementation_init_noclear(
 }
 
 
-static void lcd_implementation_nodisplay()
+inline void lcd_implementation_nodisplay()
 {
     lcd.noDisplay();
 }
-static void lcd_implementation_display()
+inline void lcd_implementation_display()
 {
     lcd.display();
 }
-
-void lcd_implementation_clear()
+inline void lcd_implementation_clear()
 {
     lcd.clear();
 }
@@ -901,7 +901,7 @@ static void lcd_implementation_status_screen()
 				lcd.setCursor(7, 3);
 				lcd_printPGM(PSTR("             "));
 
-				for (int dots = 0; dots < heating_status_counter; dots++)
+				for (uint16_t dots = 0; dots < heating_status_counter; dots++)
 				{
 					lcd.setCursor(7 + dots, 3);
 					lcd.print('.');
@@ -1103,6 +1103,7 @@ static void lcd_implementation_drawmenu_setting_edit_generic(uint8_t row, const 
         lcd.print(' ');
     lcd.print(data);
 }
+#if 0
 static void lcd_implementation_drawmenu_setting_edit_generic_P(uint8_t row, const char* pstr, char pre_char, const char* data)
 {
     char c;
@@ -1125,6 +1126,7 @@ static void lcd_implementation_drawmenu_setting_edit_generic_P(uint8_t row, cons
         lcd.print(' ');
     lcd_printPGM(data);
 }
+#endif
 #define lcd_implementation_drawmenu_setting_edit_int3_selected(row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(row, pstr, '>', itostr3(*(data)))
 #define lcd_implementation_drawmenu_setting_edit_int3(row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(row, pstr, ' ', itostr3(*(data)))
 #define lcd_implementation_drawmenu_setting_edit_float3_selected(row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(row, pstr, '>', ftostr3(*(data)))
@@ -1202,12 +1204,6 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
 
     lcd.setCursor(0, row);
     lcd.print('>');
-    if (longFilename[0] != '\0')
-    {
-
-        filename = longFilename;
-        //longFilename[LCD_WIDTH-1] = '\0';
-    }
 
     int i = 1;
     int j = 0;
@@ -1229,8 +1225,8 @@ static void lcd_implementation_drawmenu_sdfile_selected(uint8_t row, const char*
             if(LCD_CLICKED || ( enc_dif != encoderDiff )){
 				longFilenameTMP = longFilename;
 				*(longFilenameTMP + LCD_WIDTH - 2) = '\0';
-				int i = 1;
-				int j = 0;				
+				i = 1;
+				j = 0;
 				break;
             }else{
 				if (j == 1) delay(3);	//wait around 1.2 s to start scrolling text

--- a/Firmware/variants/1_75mm_MK1-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK1-RAMBo10a-E3Dv6full.h
@@ -392,7 +392,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 

--- a/Firmware/variants/1_75mm_MK1-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK1-RAMBo13a-E3Dv6full.h
@@ -392,7 +392,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo10a-E3Dv6full.h
@@ -387,7 +387,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 

--- a/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-MultiMaterial-RAMBo13a-E3Dv6full.h
@@ -389,7 +389,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 

--- a/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo10a-E3Dv6full.h
@@ -387,7 +387,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 

--- a/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
+++ b/Firmware/variants/1_75mm_MK2-RAMBo13a-E3Dv6full.h
@@ -389,7 +389,7 @@ THERMISTORS SETTINGS
 
 #define PING_TIME 60 //time in s
 #define PING_TIME_LONG 600 //10 min; used when length of commands buffer > 0 to avoid false triggering when dealing with long gcodes
-#define PING_ALLERT_PERIOD 60 //time in s
+#define PING_ALERT_PERIOD 60 //time in s
 #define NC_TIME 10 //time in s for periodic important status messages sending which needs reponse from monitoring
 #define NC_BUTTON_LONG_PRESS 15 //time in s
 


### PR DESCRIPTION
Updated to: 3.1.0-RC1

Some of the format changes introduced were done to improve readabilty and
remove compiler warnings about needing parenthesis

Some code restructuring has been done to eliminate unused code and variables

Cleanup defined but unused functions